### PR TITLE
Add data pipeline artifacts for 1 entities

### DIFF
--- a/curated/ddl/Salesforce_address/docs/Salesforce_address_README.md
+++ b/curated/ddl/Salesforce_address/docs/Salesforce_address_README.md
@@ -6,10 +6,17 @@ This document describes the data pipeline for the Salesforce_address entity, inc
 ## Entity Information
 - **Raw Entity**: Salesforce_address
 - **Curated Entity**: Salesforce_address
-- **Generated**: 2025-08-26T09:01:50.691Z
+- **Generated**: 2025-08-26T09:11:15.855Z
 
 ## Column Mappings
-
+- **AddressID** → **AddressID**: Direct mapping
+- **CustomerID** → **CustomerID**: Direct mapping
+- **Street** → **Street**: Direct mapping
+- **City** → **City**: Direct mapping
+- **State** → **State**: Direct mapping
+- **Postcode** → **Postcode**: Direct mapping
+- **Country** → **Country**: Direct mapping
+- **AddressType** → **AddressType**: Direct mapping
 
 ## Column Descriptions
 

--- a/curated/ddl/Salesforce_address/pyspark/Salesforce_address_schema_changes.py
+++ b/curated/ddl/Salesforce_address/pyspark/Salesforce_address_schema_changes.py
@@ -1,0 +1,64 @@
+# ALTER Commands for Entity: Salesforce_address
+# Generated on: 2025-08-26T09:11:15.855Z
+# These commands handle schema changes when new columns are added or existing columns are modified
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# Initialize Spark session
+spark = SparkSession.builder \
+    .appName("Salesforce_address_Schema_Changes") \
+    .config("spark.sql.adaptive.enabled", "true") \
+    .getOrCreate()
+
+# Add control columns for data lineage
+def add_control_columns(df):
+    """Add control columns for data lineage and auditability"""
+    df = df.withColumn("_ingest_timestamp", current_timestamp())
+    df = df.withColumn("_source_system", lit("raw_Salesforce_address"))
+    df = df.withColumn("_record_status", lit("valid"))
+    df = df.withColumn("_update_timestamp", current_timestamp())
+    df = df.withColumn("_batch_id", lit("batch_1756199475855"))
+    df = df.withColumn("_created_by", lit("system"))
+    df = df.withColumn("_updated_by", lit("system"))
+    return df
+
+# Schema evolution functions
+def evolve_schema(df, new_schema):
+    """Evolve the dataframe schema to match new requirements"""
+    current_schema = df.schema
+    
+    # Add missing columns
+    for field in new_schema.fields:
+        if field.name not in [f.name for f in current_schema.fields]:
+            df = df.withColumn(field.name, lit(None).cast(field.dataType))
+    
+    return df
+
+# Column modification functions
+def modify_column_type(df, column_name, new_type):
+    """Modify column data type"""
+    return df.withColumn(column_name, col(column_name).cast(new_type))
+
+def rename_column(df, old_name, new_name):
+    """Rename a column"""
+    return df.withColumnRenamed(old_name, new_name)
+
+# Main execution
+if __name__ == "__main__":
+    # Read existing data
+    df = spark.read.parquet("path/to/curated/Salesforce_address")
+    
+    # Apply schema changes
+    df = add_control_columns(df)
+    
+    # Write updated schema
+    df.write.mode("overwrite").parquet("path/to/curated/Salesforce_address_updated")
+    
+    print("Schema changes applied successfully")
+    
+    # Show final schema
+    df.printSchema()
+    
+    spark.stop()

--- a/curated/ddl/Salesforce_address/sql/Salesforce_address_schema_changes.sql
+++ b/curated/ddl/Salesforce_address/sql/Salesforce_address_schema_changes.sql
@@ -1,0 +1,26 @@
+-- ALTER Commands for Entity: Salesforce_address
+-- Generated on: 2025-08-26T09:11:15.855Z
+-- These commands handle schema changes when new columns are added or existing columns are modified
+
+-- Add control columns for data lineage (if not already present)
+-- ALTER TABLE Salesforce_address ADD COLUMN _ingest_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _source_system VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _record_status VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _update_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _batch_id VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _created_by VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_address ADD COLUMN _updated_by VARCHAR(255); -- Uncomment if needed
+
+-- Column modifications (uncomment and modify as needed)
+-- ALTER TABLE Salesforce_address MODIFY COLUMN column_name new_data_type;
+-- ALTER TABLE Salesforce_address CHANGE COLUMN old_name new_name new_data_type;
+
+-- Column constraints (uncomment and modify as needed)
+-- ALTER TABLE Salesforce_address ADD CONSTRAINT constraint_name CHECK (condition);
+-- ALTER TABLE Salesforce_address ADD INDEX index_name (column_name);
+
+-- Drop columns (commented out for safety - uncomment and modify as needed)
+-- ALTER TABLE Salesforce_address DROP COLUMN column_name;
+
+-- Note: Review and modify these commands before executing in production
+-- Some databases may require different syntax for ALTER operations

--- a/curated/ddl/Salesforce_address/sql/Salesforce_address_transform.sql
+++ b/curated/ddl/Salesforce_address/sql/Salesforce_address_transform.sql
@@ -2,10 +2,29 @@
 -- Create curated table with transformations
 
 CREATE TABLE IF NOT EXISTS Salesforce_address (
+    AddressID VARCHAR(255),
+    CustomerID VARCHAR(255),
+    Street VARCHAR(255),
+    City VARCHAR(255),
+    State VARCHAR(255),
+    Postcode VARCHAR(255),
+    Country VARCHAR(255),
+    AddressType VARCHAR(255),
+    updated_at TIMESTAMP,
+    version VARCHAR(255),
+    is_deleted BOOLEAN
 );
 
 -- Insert transformed data
 INSERT INTO Salesforce_address
 SELECT
+    AddressID as AddressID,
+    CustomerID as CustomerID,
+    Street as Street,
+    City as City,
+    State as State,
+    Postcode as Postcode,
+    Country as Country,
+    AddressType as AddressType
 FROM raw_Salesforce_address;
 

--- a/curated/dml/Salesforce_address/pyspark/Salesforce_address_dml.py
+++ b/curated/dml/Salesforce_address/pyspark/Salesforce_address_dml.py
@@ -1,5 +1,5 @@
 # DML Operations for Salesforce_address
-# Generated on: 2025-08-26T09:01:50.691Z
+# Generated on: 2025-08-26T09:11:15.855Z
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
@@ -22,7 +22,14 @@ new_records = raw_df.join(curated_df, "id", "left_anti")
 if new_records.count() > 0:
     # Transform new records according to mappings
     transformed_new = new_records.select(
-
+        col("AddressID").alias("AddressID"),
+        col("CustomerID").alias("CustomerID"),
+        col("Street").alias("Street"),
+        col("City").alias("City"),
+        col("State").alias("State"),
+        col("Postcode").alias("Postcode"),
+        col("Country").alias("Country"),
+        col("AddressType").alias("AddressType")
     )
     
     # Add control columns

--- a/curated/dml/Salesforce_address/sql/Salesforce_address_dml.sql
+++ b/curated/dml/Salesforce_address/sql/Salesforce_address_dml.sql
@@ -1,12 +1,36 @@
 -- DML Operations for Salesforce_address
--- Generated on: 2025-08-26T09:01:50.691Z
+-- Generated on: 2025-08-26T09:11:15.855Z
 
 -- Insert new records into curated table
 INSERT INTO curated.Salesforce_address (
-  
+  AddressID,
+  CustomerID,
+  Street,
+  City,
+  State,
+  Postcode,
+  Country,
+  AddressType,
+  updated_at,
+  version,
+  is_deleted,
+  _ingest_timestamp,
+  _source_system,
+  _record_status,
+  _update_timestamp,
+  _batch_id,
+  _created_by,
+  _updated_by
 )
 SELECT 
-
+  AddressID as AddressID,
+  CustomerID as CustomerID,
+  Street as Street,
+  City as City,
+  State as State,
+  Postcode as Postcode,
+  Country as Country,
+  AddressType as AddressType
 FROM raw.Salesforce_address;
 
 -- Update existing records


### PR DESCRIPTION
## Summary
This PR adds data pipeline artifacts for 1 entities: Salesforce_address

## Changes
- Generated SQL transformations for all entities
- Generated PySpark transformations for all entities
- All artifacts follow the standard pipeline structure

## Files Added
- `curated/ddl/Salesforce_address/sql/Salesforce_address_transform.sql`
- `curated/ddl/Salesforce_address/pyspark/Salesforce_address_transform.py`
- `curated/dml/Salesforce_address/sql/Salesforce_address_dml.sql`
- `curated/dml/Salesforce_address/pyspark/Salesforce_address_dml.py`
- `curated/ddl/Salesforce_address/sql/Salesforce_address_schema_changes.sql`
- `curated/ddl/Salesforce_address/pyspark/Salesforce_address_schema_changes.py`
- `curated/ddl/Salesforce_address/config/Salesforce_address_config.yaml`
- `curated/ddl/Salesforce_address/config/requirements.txt`
- `curated/ddl/Salesforce_address/docs/Salesforce_address_README.md`
- `curated/ddl/Salesforce_address/.github/workflows/Salesforce_address_pipeline.yml`
- `curated/ddl/Salesforce_address/Dockerfile`

## Branch
- Source: `nexa-ai-Salesforce_address-1756199491462`
- Target: `main`

## Commit
Add data pipeline artifacts for 1 entities: Salesforce_address

---
*Generated by DR.ai Application*