### PR TITLE
Add data pipeline artifacts for 1 entities

### DIFF
--- a/curated/ddl/Salesforce_DimOrder/docs/Salesforce_DimOrder_README.md
+++ b/curated/ddl/Salesforce_DimOrder/docs/Salesforce_DimOrder_README.md
@@ -6,10 +6,17 @@ This document describes the data pipeline for the Salesforce_DimOrder entity, in
 ## Entity Information
 - **Raw Entity**: Salesforce_DimOrder
 - **Curated Entity**: Salesforce_DimOrder
-- **Generated**: 2025-08-26T09:01:44.712Z
+- **Generated**: 2025-08-26T09:18:51.782Z
 
 ## Column Mappings
-
+- **order_id** → **order_id**: Direct mapping
+- **customer_id** → **customer_id**: Direct mapping
+- **order_date** → **order_date**: Direct mapping
+- **order_status** → **order_status**: Direct mapping
+- **order_type** → **order_type**: Direct mapping
+- **channel** → **channel**: Direct mapping
+- **amount** → **amount**: Direct mapping
+- **last_updated** → **last_updated**: Direct mapping
 
 ## Column Descriptions
 

--- a/curated/ddl/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_schema_changes.py
+++ b/curated/ddl/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_schema_changes.py
@@ -1,0 +1,64 @@
+# ALTER Commands for Entity: Salesforce_DimOrder
+# Generated on: 2025-08-26T09:18:51.782Z
+# These commands handle schema changes when new columns are added or existing columns are modified
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# Initialize Spark session
+spark = SparkSession.builder \
+    .appName("Salesforce_DimOrder_Schema_Changes") \
+    .config("spark.sql.adaptive.enabled", "true") \
+    .getOrCreate()
+
+# Add control columns for data lineage
+def add_control_columns(df):
+    """Add control columns for data lineage and auditability"""
+    df = df.withColumn("_ingest_timestamp", current_timestamp())
+    df = df.withColumn("_source_system", lit("raw_Salesforce_DimOrder"))
+    df = df.withColumn("_record_status", lit("valid"))
+    df = df.withColumn("_update_timestamp", current_timestamp())
+    df = df.withColumn("_batch_id", lit("batch_1756199931782"))
+    df = df.withColumn("_created_by", lit("system"))
+    df = df.withColumn("_updated_by", lit("system"))
+    return df
+
+# Schema evolution functions
+def evolve_schema(df, new_schema):
+    """Evolve the dataframe schema to match new requirements"""
+    current_schema = df.schema
+    
+    # Add missing columns
+    for field in new_schema.fields:
+        if field.name not in [f.name for f in current_schema.fields]:
+            df = df.withColumn(field.name, lit(None).cast(field.dataType))
+    
+    return df
+
+# Column modification functions
+def modify_column_type(df, column_name, new_type):
+    """Modify column data type"""
+    return df.withColumn(column_name, col(column_name).cast(new_type))
+
+def rename_column(df, old_name, new_name):
+    """Rename a column"""
+    return df.withColumnRenamed(old_name, new_name)
+
+# Main execution
+if __name__ == "__main__":
+    # Read existing data
+    df = spark.read.parquet("path/to/curated/Salesforce_DimOrder")
+    
+    # Apply schema changes
+    df = add_control_columns(df)
+    
+    # Write updated schema
+    df.write.mode("overwrite").parquet("path/to/curated/Salesforce_DimOrder_updated")
+    
+    print("Schema changes applied successfully")
+    
+    # Show final schema
+    df.printSchema()
+    
+    spark.stop()

--- a/curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_schema_changes.sql
+++ b/curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_schema_changes.sql
@@ -1,0 +1,26 @@
+-- ALTER Commands for Entity: Salesforce_DimOrder
+-- Generated on: 2025-08-26T09:18:51.782Z
+-- These commands handle schema changes when new columns are added or existing columns are modified
+
+-- Add control columns for data lineage (if not already present)
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _ingest_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _source_system VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _record_status VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _update_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _batch_id VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _created_by VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Salesforce_DimOrder ADD COLUMN _updated_by VARCHAR(255); -- Uncomment if needed
+
+-- Column modifications (uncomment and modify as needed)
+-- ALTER TABLE Salesforce_DimOrder MODIFY COLUMN column_name new_data_type;
+-- ALTER TABLE Salesforce_DimOrder CHANGE COLUMN old_name new_name new_data_type;
+
+-- Column constraints (uncomment and modify as needed)
+-- ALTER TABLE Salesforce_DimOrder ADD CONSTRAINT constraint_name CHECK (condition);
+-- ALTER TABLE Salesforce_DimOrder ADD INDEX index_name (column_name);
+
+-- Drop columns (commented out for safety - uncomment and modify as needed)
+-- ALTER TABLE Salesforce_DimOrder DROP COLUMN column_name;
+
+-- Note: Review and modify these commands before executing in production
+-- Some databases may require different syntax for ALTER operations

--- a/curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_transform.sql
+++ b/curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_transform.sql
@@ -2,10 +2,29 @@
 -- Create curated table with transformations
 
 CREATE TABLE IF NOT EXISTS Salesforce_DimOrder (
+    order_id BIGINT,
+    customer_id BIGINT,
+    order_date TIMESTAMP,
+    order_status VARCHAR(255),
+    order_type VARCHAR(255),
+    channel VARCHAR(255),
+    amount DECIMAL(10,2),
+    last_updated TIMESTAMP,
+    updated_at TIMESTAMP,
+    version VARCHAR(255),
+    is_deleted BOOLEAN
 );
 
 -- Insert transformed data
 INSERT INTO Salesforce_DimOrder
 SELECT
+    order_id as order_id,
+    customer_id as customer_id,
+    order_date as order_date,
+    order_status as order_status,
+    order_type as order_type,
+    channel as channel,
+    amount as amount,
+    last_updated as last_updated
 FROM raw_Salesforce_DimOrder;
 

--- a/curated/dml/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_dml.py
+++ b/curated/dml/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_dml.py
@@ -1,5 +1,5 @@
 # DML Operations for Salesforce_DimOrder
-# Generated on: 2025-08-26T09:01:44.712Z
+# Generated on: 2025-08-26T09:18:51.782Z
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
@@ -22,7 +22,14 @@ new_records = raw_df.join(curated_df, "id", "left_anti")
 if new_records.count() > 0:
     # Transform new records according to mappings
     transformed_new = new_records.select(
-
+        col("order_id").alias("order_id"),
+        col("customer_id").alias("customer_id"),
+        col("order_date").alias("order_date"),
+        col("order_status").alias("order_status"),
+        col("order_type").alias("order_type"),
+        col("channel").alias("channel"),
+        col("amount").alias("amount"),
+        col("last_updated").alias("last_updated")
     )
     
     # Add control columns

--- a/curated/dml/Salesforce_DimOrder/sql/Salesforce_DimOrder_dml.sql
+++ b/curated/dml/Salesforce_DimOrder/sql/Salesforce_DimOrder_dml.sql
@@ -1,12 +1,36 @@
 -- DML Operations for Salesforce_DimOrder
--- Generated on: 2025-08-26T09:01:44.712Z
+-- Generated on: 2025-08-26T09:18:51.782Z
 
 -- Insert new records into curated table
 INSERT INTO curated.Salesforce_DimOrder (
-  
+  order_id,
+  customer_id,
+  order_date,
+  order_status,
+  order_type,
+  channel,
+  amount,
+  last_updated,
+  updated_at,
+  version,
+  is_deleted,
+  _ingest_timestamp,
+  _source_system,
+  _record_status,
+  _update_timestamp,
+  _batch_id,
+  _created_by,
+  _updated_by
 )
 SELECT 
-
+  order_id as order_id,
+  customer_id as customer_id,
+  order_date as order_date,
+  order_status as order_status,
+  order_type as order_type,
+  channel as channel,
+  amount as amount,
+  last_updated as last_updated
 FROM raw.Salesforce_DimOrder;
 
 -- Update existing records


### PR DESCRIPTION
## Summary
This PR adds data pipeline artifacts for 1 entities: Salesforce_DimOrder

## Changes
- Generated SQL transformations for all entities
- Generated PySpark transformations for all entities
- All artifacts follow the standard pipeline structure

## Files Added
- `curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_transform.sql`
- `curated/ddl/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_transform.py`
- `curated/dml/Salesforce_DimOrder/sql/Salesforce_DimOrder_dml.sql`
- `curated/dml/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_dml.py`
- `curated/ddl/Salesforce_DimOrder/sql/Salesforce_DimOrder_schema_changes.sql`
- `curated/ddl/Salesforce_DimOrder/pyspark/Salesforce_DimOrder_schema_changes.py`
- `curated/ddl/Salesforce_DimOrder/config/Salesforce_DimOrder_config.yaml`
- `curated/ddl/Salesforce_DimOrder/config/requirements.txt`
- `curated/ddl/Salesforce_DimOrder/docs/Salesforce_DimOrder_README.md`
- `curated/ddl/Salesforce_DimOrder/.github/workflows/Salesforce_DimOrder_pipeline.yml`
- `curated/ddl/Salesforce_DimOrder/Dockerfile`

## Branch
- Source: `nexa-ai-Salesforce_DimOrder-1756199937670`
- Target: `main`

## Commit
Add data pipeline artifacts for 1 entities: Salesforce_DimOrder

---
*Generated by DR.ai Application*