### PR TITLE
Add data pipeline artifacts for 1 entities

### DIFF
--- a/curated/ddl/Provisioning_subscriber/docs/Provisioning_subscriber_README.md
+++ b/curated/ddl/Provisioning_subscriber/docs/Provisioning_subscriber_README.md
@@ -6,10 +6,17 @@ This document describes the data pipeline for the Provisioning_subscriber entity
 ## Entity Information
 - **Raw Entity**: Provisioning_subscriber
 - **Curated Entity**: Provisioning_subscriber
-- **Generated**: 2025-08-26T09:01:54.716Z
+- **Generated**: 2025-08-26T09:18:51.804Z
 
 ## Column Mappings
-
+- **sub_id** → **sub_id**: Direct mapping
+- **contract_ref** → **contract_ref**: Direct mapping
+- **msisdn** → **msisdn**: Direct mapping
+- **sim** → **sim**: Direct mapping
+- **device_ref** → **device_ref**: Direct mapping
+- **sub_type** → **sub_type**: Direct mapping
+- **sub_status** → **sub_status**: Direct mapping
+- **activated** → **activated**: Direct mapping
 
 ## Column Descriptions
 

--- a/curated/ddl/Provisioning_subscriber/pyspark/Provisioning_subscriber_schema_changes.py
+++ b/curated/ddl/Provisioning_subscriber/pyspark/Provisioning_subscriber_schema_changes.py
@@ -1,0 +1,64 @@
+# ALTER Commands for Entity: Provisioning_subscriber
+# Generated on: 2025-08-26T09:18:51.804Z
+# These commands handle schema changes when new columns are added or existing columns are modified
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# Initialize Spark session
+spark = SparkSession.builder \
+    .appName("Provisioning_subscriber_Schema_Changes") \
+    .config("spark.sql.adaptive.enabled", "true") \
+    .getOrCreate()
+
+# Add control columns for data lineage
+def add_control_columns(df):
+    """Add control columns for data lineage and auditability"""
+    df = df.withColumn("_ingest_timestamp", current_timestamp())
+    df = df.withColumn("_source_system", lit("raw_Provisioning_subscriber"))
+    df = df.withColumn("_record_status", lit("valid"))
+    df = df.withColumn("_update_timestamp", current_timestamp())
+    df = df.withColumn("_batch_id", lit("batch_1756199931804"))
+    df = df.withColumn("_created_by", lit("system"))
+    df = df.withColumn("_updated_by", lit("system"))
+    return df
+
+# Schema evolution functions
+def evolve_schema(df, new_schema):
+    """Evolve the dataframe schema to match new requirements"""
+    current_schema = df.schema
+    
+    # Add missing columns
+    for field in new_schema.fields:
+        if field.name not in [f.name for f in current_schema.fields]:
+            df = df.withColumn(field.name, lit(None).cast(field.dataType))
+    
+    return df
+
+# Column modification functions
+def modify_column_type(df, column_name, new_type):
+    """Modify column data type"""
+    return df.withColumn(column_name, col(column_name).cast(new_type))
+
+def rename_column(df, old_name, new_name):
+    """Rename a column"""
+    return df.withColumnRenamed(old_name, new_name)
+
+# Main execution
+if __name__ == "__main__":
+    # Read existing data
+    df = spark.read.parquet("path/to/curated/Provisioning_subscriber")
+    
+    # Apply schema changes
+    df = add_control_columns(df)
+    
+    # Write updated schema
+    df.write.mode("overwrite").parquet("path/to/curated/Provisioning_subscriber_updated")
+    
+    print("Schema changes applied successfully")
+    
+    # Show final schema
+    df.printSchema()
+    
+    spark.stop()

--- a/curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_schema_changes.sql
+++ b/curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_schema_changes.sql
@@ -1,0 +1,26 @@
+-- ALTER Commands for Entity: Provisioning_subscriber
+-- Generated on: 2025-08-26T09:18:51.804Z
+-- These commands handle schema changes when new columns are added or existing columns are modified
+
+-- Add control columns for data lineage (if not already present)
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _ingest_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _source_system VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _record_status VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _update_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _batch_id VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _created_by VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE Provisioning_subscriber ADD COLUMN _updated_by VARCHAR(255); -- Uncomment if needed
+
+-- Column modifications (uncomment and modify as needed)
+-- ALTER TABLE Provisioning_subscriber MODIFY COLUMN column_name new_data_type;
+-- ALTER TABLE Provisioning_subscriber CHANGE COLUMN old_name new_name new_data_type;
+
+-- Column constraints (uncomment and modify as needed)
+-- ALTER TABLE Provisioning_subscriber ADD CONSTRAINT constraint_name CHECK (condition);
+-- ALTER TABLE Provisioning_subscriber ADD INDEX index_name (column_name);
+
+-- Drop columns (commented out for safety - uncomment and modify as needed)
+-- ALTER TABLE Provisioning_subscriber DROP COLUMN column_name;
+
+-- Note: Review and modify these commands before executing in production
+-- Some databases may require different syntax for ALTER operations

--- a/curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_transform.sql
+++ b/curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_transform.sql
@@ -2,10 +2,29 @@
 -- Create curated table with transformations
 
 CREATE TABLE IF NOT EXISTS Provisioning_subscriber (
+    sub_id BIGINT,
+    contract_ref VARCHAR(255),
+    msisdn VARCHAR(255),
+    sim VARCHAR(255),
+    device_ref VARCHAR(255),
+    sub_type VARCHAR(255),
+    sub_status VARCHAR(255),
+    activated VARCHAR(255),
+    updated_at TIMESTAMP,
+    version VARCHAR(255),
+    is_deleted BOOLEAN
 );
 
 -- Insert transformed data
 INSERT INTO Provisioning_subscriber
 SELECT
+    sub_id as sub_id,
+    contract_ref as contract_ref,
+    msisdn as msisdn,
+    sim as sim,
+    device_ref as device_ref,
+    sub_type as sub_type,
+    sub_status as sub_status,
+    activated as activated
 FROM raw_Provisioning_subscriber;
 

--- a/curated/dml/Provisioning_subscriber/pyspark/Provisioning_subscriber_dml.py
+++ b/curated/dml/Provisioning_subscriber/pyspark/Provisioning_subscriber_dml.py
@@ -1,5 +1,5 @@
 # DML Operations for Provisioning_subscriber
-# Generated on: 2025-08-26T09:01:54.716Z
+# Generated on: 2025-08-26T09:18:51.804Z
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
@@ -22,7 +22,14 @@ new_records = raw_df.join(curated_df, "id", "left_anti")
 if new_records.count() > 0:
     # Transform new records according to mappings
     transformed_new = new_records.select(
-
+        col("sub_id").alias("sub_id"),
+        col("contract_ref").alias("contract_ref"),
+        col("msisdn").alias("msisdn"),
+        col("sim").alias("sim"),
+        col("device_ref").alias("device_ref"),
+        col("sub_type").alias("sub_type"),
+        col("sub_status").alias("sub_status"),
+        col("activated").alias("activated")
     )
     
     # Add control columns

--- a/curated/dml/Provisioning_subscriber/sql/Provisioning_subscriber_dml.sql
+++ b/curated/dml/Provisioning_subscriber/sql/Provisioning_subscriber_dml.sql
@@ -1,12 +1,36 @@
 -- DML Operations for Provisioning_subscriber
--- Generated on: 2025-08-26T09:01:54.716Z
+-- Generated on: 2025-08-26T09:18:51.804Z
 
 -- Insert new records into curated table
 INSERT INTO curated.Provisioning_subscriber (
-  
+  sub_id,
+  contract_ref,
+  msisdn,
+  sim,
+  device_ref,
+  sub_type,
+  sub_status,
+  activated,
+  updated_at,
+  version,
+  is_deleted,
+  _ingest_timestamp,
+  _source_system,
+  _record_status,
+  _update_timestamp,
+  _batch_id,
+  _created_by,
+  _updated_by
 )
 SELECT 
-
+  sub_id as sub_id,
+  contract_ref as contract_ref,
+  msisdn as msisdn,
+  sim as sim,
+  device_ref as device_ref,
+  sub_type as sub_type,
+  sub_status as sub_status,
+  activated as activated
 FROM raw.Provisioning_subscriber;
 
 -- Update existing records


### PR DESCRIPTION
## Summary
This PR adds data pipeline artifacts for 1 entities: Provisioning_subscriber

## Changes
- Generated SQL transformations for all entities
- Generated PySpark transformations for all entities
- All artifacts follow the standard pipeline structure

## Files Added
- `curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_transform.sql`
- `curated/ddl/Provisioning_subscriber/pyspark/Provisioning_subscriber_transform.py`
- `curated/dml/Provisioning_subscriber/sql/Provisioning_subscriber_dml.sql`
- `curated/dml/Provisioning_subscriber/pyspark/Provisioning_subscriber_dml.py`
- `curated/ddl/Provisioning_subscriber/sql/Provisioning_subscriber_schema_changes.sql`
- `curated/ddl/Provisioning_subscriber/pyspark/Provisioning_subscriber_schema_changes.py`
- `curated/ddl/Provisioning_subscriber/config/Provisioning_subscriber_config.yaml`
- `curated/ddl/Provisioning_subscriber/config/requirements.txt`
- `curated/ddl/Provisioning_subscriber/docs/Provisioning_subscriber_README.md`
- `curated/ddl/Provisioning_subscriber/.github/workflows/Provisioning_subscriber_pipeline.yml`
- `curated/ddl/Provisioning_subscriber/Dockerfile`

## Branch
- Source: `nexa-ai-Provisioning_subscriber-1756199953124`
- Target: `main`

## Commit
Add data pipeline artifacts for 1 entities: Provisioning_subscriber

---
*Generated by DR.ai Application*