### PR TITLE
Add data pipeline artifacts for 1 entities

### DIFF
--- a/curated/ddl/CatalogDB_product/docs/CatalogDB_product_README.md
+++ b/curated/ddl/CatalogDB_product/docs/CatalogDB_product_README.md
@@ -6,10 +6,16 @@ This document describes the data pipeline for the CatalogDB_product entity, incl
 ## Entity Information
 - **Raw Entity**: CatalogDB_product
 - **Curated Entity**: CatalogDB_product
-- **Generated**: 2025-08-26T09:02:01.299Z
+- **Generated**: 2025-08-26T09:18:51.816Z
 
 ## Column Mappings
-
+- **prod_id** → **prod_id**: Direct mapping
+- **svc_id** → **svc_id**: Direct mapping
+- **prod_name** → **prod_name**: Direct mapping
+- **prod_type** → **prod_type**: Direct mapping
+- **bundle** → **bundle**: Direct mapping
+- **plan** → **plan**: Direct mapping
+- **discount** → **discount**: Direct mapping
 
 ## Column Descriptions
 

--- a/curated/ddl/CatalogDB_product/pyspark/CatalogDB_product_schema_changes.py
+++ b/curated/ddl/CatalogDB_product/pyspark/CatalogDB_product_schema_changes.py
@@ -1,0 +1,64 @@
+# ALTER Commands for Entity: CatalogDB_product
+# Generated on: 2025-08-26T09:18:51.816Z
+# These commands handle schema changes when new columns are added or existing columns are modified
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# Initialize Spark session
+spark = SparkSession.builder \
+    .appName("CatalogDB_product_Schema_Changes") \
+    .config("spark.sql.adaptive.enabled", "true") \
+    .getOrCreate()
+
+# Add control columns for data lineage
+def add_control_columns(df):
+    """Add control columns for data lineage and auditability"""
+    df = df.withColumn("_ingest_timestamp", current_timestamp())
+    df = df.withColumn("_source_system", lit("raw_CatalogDB_product"))
+    df = df.withColumn("_record_status", lit("valid"))
+    df = df.withColumn("_update_timestamp", current_timestamp())
+    df = df.withColumn("_batch_id", lit("batch_1756199931816"))
+    df = df.withColumn("_created_by", lit("system"))
+    df = df.withColumn("_updated_by", lit("system"))
+    return df
+
+# Schema evolution functions
+def evolve_schema(df, new_schema):
+    """Evolve the dataframe schema to match new requirements"""
+    current_schema = df.schema
+    
+    # Add missing columns
+    for field in new_schema.fields:
+        if field.name not in [f.name for f in current_schema.fields]:
+            df = df.withColumn(field.name, lit(None).cast(field.dataType))
+    
+    return df
+
+# Column modification functions
+def modify_column_type(df, column_name, new_type):
+    """Modify column data type"""
+    return df.withColumn(column_name, col(column_name).cast(new_type))
+
+def rename_column(df, old_name, new_name):
+    """Rename a column"""
+    return df.withColumnRenamed(old_name, new_name)
+
+# Main execution
+if __name__ == "__main__":
+    # Read existing data
+    df = spark.read.parquet("path/to/curated/CatalogDB_product")
+    
+    # Apply schema changes
+    df = add_control_columns(df)
+    
+    # Write updated schema
+    df.write.mode("overwrite").parquet("path/to/curated/CatalogDB_product_updated")
+    
+    print("Schema changes applied successfully")
+    
+    # Show final schema
+    df.printSchema()
+    
+    spark.stop()

--- a/curated/ddl/CatalogDB_product/sql/CatalogDB_product_schema_changes.sql
+++ b/curated/ddl/CatalogDB_product/sql/CatalogDB_product_schema_changes.sql
@@ -1,0 +1,26 @@
+-- ALTER Commands for Entity: CatalogDB_product
+-- Generated on: 2025-08-26T09:18:51.816Z
+-- These commands handle schema changes when new columns are added or existing columns are modified
+
+-- Add control columns for data lineage (if not already present)
+-- ALTER TABLE CatalogDB_product ADD COLUMN _ingest_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _source_system VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _record_status VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _update_timestamp VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _batch_id VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _created_by VARCHAR(255); -- Uncomment if needed
+-- ALTER TABLE CatalogDB_product ADD COLUMN _updated_by VARCHAR(255); -- Uncomment if needed
+
+-- Column modifications (uncomment and modify as needed)
+-- ALTER TABLE CatalogDB_product MODIFY COLUMN column_name new_data_type;
+-- ALTER TABLE CatalogDB_product CHANGE COLUMN old_name new_name new_data_type;
+
+-- Column constraints (uncomment and modify as needed)
+-- ALTER TABLE CatalogDB_product ADD CONSTRAINT constraint_name CHECK (condition);
+-- ALTER TABLE CatalogDB_product ADD INDEX index_name (column_name);
+
+-- Drop columns (commented out for safety - uncomment and modify as needed)
+-- ALTER TABLE CatalogDB_product DROP COLUMN column_name;
+
+-- Note: Review and modify these commands before executing in production
+-- Some databases may require different syntax for ALTER operations

--- a/curated/ddl/CatalogDB_product/sql/CatalogDB_product_transform.sql
+++ b/curated/ddl/CatalogDB_product/sql/CatalogDB_product_transform.sql
@@ -2,10 +2,27 @@
 -- Create curated table with transformations
 
 CREATE TABLE IF NOT EXISTS CatalogDB_product (
+    prod_id BIGINT,
+    svc_id BIGINT,
+    prod_name VARCHAR(255),
+    prod_type VARCHAR(255),
+    bundle VARCHAR(255),
+    plan VARCHAR(255),
+    discount INTEGER,
+    updated_at TIMESTAMP,
+    version VARCHAR(255),
+    is_deleted BOOLEAN
 );
 
 -- Insert transformed data
 INSERT INTO CatalogDB_product
 SELECT
+    prod_id as prod_id,
+    svc_id as svc_id,
+    prod_name as prod_name,
+    prod_type as prod_type,
+    bundle as bundle,
+    plan as plan,
+    discount as discount
 FROM raw_CatalogDB_product;
 

--- a/curated/dml/CatalogDB_product/pyspark/CatalogDB_product_dml.py
+++ b/curated/dml/CatalogDB_product/pyspark/CatalogDB_product_dml.py
@@ -1,5 +1,5 @@
 # DML Operations for CatalogDB_product
-# Generated on: 2025-08-26T09:02:01.299Z
+# Generated on: 2025-08-26T09:18:51.816Z
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
@@ -22,7 +22,13 @@ new_records = raw_df.join(curated_df, "id", "left_anti")
 if new_records.count() > 0:
     # Transform new records according to mappings
     transformed_new = new_records.select(
-
+        col("prod_id").alias("prod_id"),
+        col("svc_id").alias("svc_id"),
+        col("prod_name").alias("prod_name"),
+        col("prod_type").alias("prod_type"),
+        col("bundle").alias("bundle"),
+        col("plan").alias("plan"),
+        col("discount").alias("discount")
     )
     
     # Add control columns

--- a/curated/dml/CatalogDB_product/sql/CatalogDB_product_dml.sql
+++ b/curated/dml/CatalogDB_product/sql/CatalogDB_product_dml.sql
@@ -1,12 +1,34 @@
 -- DML Operations for CatalogDB_product
--- Generated on: 2025-08-26T09:02:01.299Z
+-- Generated on: 2025-08-26T09:18:51.816Z
 
 -- Insert new records into curated table
 INSERT INTO curated.CatalogDB_product (
-  
+  prod_id,
+  svc_id,
+  prod_name,
+  prod_type,
+  bundle,
+  plan,
+  discount,
+  updated_at,
+  version,
+  is_deleted,
+  _ingest_timestamp,
+  _source_system,
+  _record_status,
+  _update_timestamp,
+  _batch_id,
+  _created_by,
+  _updated_by
 )
 SELECT 
-
+  prod_id as prod_id,
+  svc_id as svc_id,
+  prod_name as prod_name,
+  prod_type as prod_type,
+  bundle as bundle,
+  plan as plan,
+  discount as discount
 FROM raw.CatalogDB_product;
 
 -- Update existing records


### PR DESCRIPTION
## Summary
This PR adds data pipeline artifacts for 1 entities: CatalogDB_product

## Changes
- Generated SQL transformations for all entities
- Generated PySpark transformations for all entities
- All artifacts follow the standard pipeline structure

## Files Added
- `curated/ddl/CatalogDB_product/sql/CatalogDB_product_transform.sql`
- `curated/ddl/CatalogDB_product/pyspark/CatalogDB_product_transform.py`
- `curated/dml/CatalogDB_product/sql/CatalogDB_product_dml.sql`
- `curated/dml/CatalogDB_product/pyspark/CatalogDB_product_dml.py`
- `curated/ddl/CatalogDB_product/sql/CatalogDB_product_schema_changes.sql`
- `curated/ddl/CatalogDB_product/pyspark/CatalogDB_product_schema_changes.py`
- `curated/ddl/CatalogDB_product/config/CatalogDB_product_config.yaml`
- `curated/ddl/CatalogDB_product/config/requirements.txt`
- `curated/ddl/CatalogDB_product/docs/CatalogDB_product_README.md`
- `curated/ddl/CatalogDB_product/.github/workflows/CatalogDB_product_pipeline.yml`
- `curated/ddl/CatalogDB_product/Dockerfile`

## Branch
- Source: `nexa-ai-CatalogDB_product-1756199961911`
- Target: `main`

## Commit
Add data pipeline artifacts for 1 entities: CatalogDB_product

---
*Generated by DR.ai Application*